### PR TITLE
Set offer throughput on the collection instead of the database

### DIFF
--- a/Source/v3Net/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/v3Net/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -52,22 +52,22 @@ namespace Icebreaker.Helpers
             this.documentClient = new DocumentClient(new Uri(endpointUrl), primaryKey);
 
             // Create the database if needed
-            Database db = await this.documentClient.CreateDatabaseIfNotExistsAsync(
-                new Database { Id = databaseName },
-                new RequestOptions { OfferThroughput = DefaultRequestThroughput });     // Set the throughput at database level by default
+            Database db = await this.documentClient.CreateDatabaseIfNotExistsAsync(new Database { Id = databaseName });
             if (db != null)
             {
                 telemetry.TrackTrace($"Reference to database {db.Id} obtained successfully");
             }
 
+            var requestOptions = new RequestOptions { OfferThroughput = DefaultRequestThroughput };
+
             // Get a reference to the Teams collection, creating it if needed
             var teamsCollectionDefinition = new DocumentCollection
             {
-                Id = teamsCollectionName
+                Id = teamsCollectionName,
             };
             teamsCollectionDefinition.PartitionKey.Paths.Add("/teamId");
 
-            this.teamsCollection = await this.documentClient.CreateDocumentCollectionIfNotExistsAsync(UriFactory.CreateDatabaseUri(databaseName), teamsCollectionDefinition);
+            this.teamsCollection = await this.documentClient.CreateDocumentCollectionIfNotExistsAsync(db.SelfLink, teamsCollectionDefinition, requestOptions);
             if (this.teamsCollection != null)
             {
                 telemetry.TrackTrace($"Reference to Teams collection database {this.teamsCollection.Id} obtained successfully");
@@ -80,7 +80,7 @@ namespace Icebreaker.Helpers
             };
             usersCollectionDefinition.PartitionKey.Paths.Add("/tenantId");
 
-            this.usersCollection = await this.documentClient.CreateDocumentCollectionIfNotExistsAsync(UriFactory.CreateDatabaseUri(databaseName), usersCollectionDefinition);
+            this.usersCollection = await this.documentClient.CreateDocumentCollectionIfNotExistsAsync(db.SelfLink, usersCollectionDefinition, requestOptions);
             if (this.usersCollection != null)
             {
                 telemetry.TrackTrace($"Reference to Users collection database {this.usersCollection.Id} obtained successfully");


### PR DESCRIPTION
Avoid error in cases where shared database offer is disabled for the account.