### PR TITLE
Set throughput at database level when possible

### DIFF
--- a/Source/v3Net/Icebreaker/Controllers/MessagesController.cs
+++ b/Source/v3Net/Icebreaker/Controllers/MessagesController.cs
@@ -191,7 +191,7 @@ namespace Icebreaker
                             {
                                 telemetryClient.TrackTrace($"Adding a new member: {member.Id}");
 
-                                var installedTeam = await this.bot.GetInstalledTeam(tenantId, teamsChannelData.Team.Id);
+                                var installedTeam = await this.bot.GetInstalledTeam(teamsChannelData.Team.Id);
                                 await this.bot.WelcomeUser(connectorClient, member.Id, tenantId, teamsChannelData.Team.Id, installedTeam.InstallerName);
                             }
                         }

--- a/Source/v3Net/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/v3Net/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -100,10 +100,9 @@ namespace Icebreaker.Helpers
         /// <summary>
         /// Returns the team that the bot has been installed to
         /// </summary>
-        /// <param name="tenantId">The tenant id</param>
         /// <param name="teamId">The team id</param>
         /// <returns>Team that the bot is installed to</returns>
-        public async Task<TeamInstallInfo> GetInstalledTeamAsync(string tenantId, string teamId)
+        public async Task<TeamInstallInfo> GetInstalledTeamAsync(string teamId)
         {
             telemetry.TrackTrace("Hit the GetInstalledTeam method");
 
@@ -125,10 +124,9 @@ namespace Icebreaker.Helpers
         /// <summary>
         /// Get the stored information about the given user
         /// </summary>
-        /// <param name="tenantId">Tenant id</param>
         /// <param name="userId">User id</param>
         /// <returns>User information</returns>
-        public async Task<UserInfo> GetUserInfoAsync(string tenantId, string userId)
+        public async Task<UserInfo> GetUserInfoAsync(string userId)
         {
             telemetry.TrackTrace("Hit the GetUserInfo method");
 
@@ -195,8 +193,8 @@ namespace Icebreaker.Helpers
 
             var maxPairUpHistory = Convert.ToInt64(CloudConfigurationManager.GetSetting("MaxPairUpHistory"));
 
-            var user1Info = await this.GetUserInfoAsync(tenantId, user1Id);
-            var user2Info = await this.GetUserInfoAsync(tenantId, user2Id);
+            var user1Info = await this.GetUserInfoAsync(user1Id);
+            var user2Info = await this.GetUserInfoAsync(user2Id);
 
             user1Info.RecentPairUps.Add(user2Info);
             if (user1Info.RecentPairUps.Count >= maxPairUpHistory)

--- a/Source/v3Net/Icebreaker/IcebreakerBot.cs
+++ b/Source/v3Net/Icebreaker/IcebreakerBot.cs
@@ -96,12 +96,11 @@ namespace Icebreaker
         /// <summary>
         /// Method that will return the information of the installed team
         /// </summary>
-        /// <param name="tenantId">The tenant id</param>
         /// <param name="teamId">The team id</param>
         /// <returns>The team that the bot has been installed to</returns>
-        public Task<TeamInstallInfo> GetInstalledTeam(string tenantId, string teamId)
+        public Task<TeamInstallInfo> GetInstalledTeam(string teamId)
         {
-            return this.dataProvider.GetInstalledTeamAsync(tenantId, teamId);
+            return this.dataProvider.GetInstalledTeamAsync(teamId);
         }
 
         /// <summary>
@@ -354,7 +353,7 @@ namespace Icebreaker
 
             foreach (var member in members)
             {
-                var userInfo = await this.dataProvider.GetUserInfoAsync(teamInfo.TenantId, member.AsTeamsChannelAccount().ObjectId);
+                var userInfo = await this.dataProvider.GetUserInfoAsync(member.AsTeamsChannelAccount().ObjectId);
                 if (userInfo == null || userInfo.OptedIn)
                 {
                     telemetry.TrackTrace($"Adding {member.Name} to the list at");


### PR DESCRIPTION
* Use fixed size collections: At a maximum size of 10GB, and an average size of 1KB/document, that's a maximum of 10 million teams and users, which should be more than enough.
* Set throughput at database level when possible, so Teams and Users collection can share the provisioned throughput. This requires a partition key for the collections, so set the logical partition key to be the team ID and user ID.
* Improve the way queries are handled in the data provider:
    - make query for all teams async
    - read document directly instead of running a document query that returns 1 result.
