### PR TITLE
Issue #45

### DIFF
--- a/Source/Icebreaker/Helpers/Extensions.cs
+++ b/Source/Icebreaker/Helpers/Extensions.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="Extensions.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Icebreaker.Helpers
+{
+    using System;
+
+    /// <summary>
+    /// This class contains custom methods that are being used.
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// Method that will look at having a specific text string, and having this done with case insensitive.
+        /// </summary>
+        /// <param name="text">The actual text to parse.</param>
+        /// <param name="value">The string that we are looking for.</param>
+        /// <param name="stringComparison">The string comparator.</param>
+        /// <returns>A value saying whether or not a specific string exists.</returns>
+        public static bool CaseInsensitiveContains(
+            this string text,
+            string value,
+            StringComparison stringComparison = StringComparison.CurrentCultureIgnoreCase)
+        {
+            return text.IndexOf(value, stringComparison) >= 0;
+        }
+    }
+}

--- a/Source/Icebreaker/Icebreaker.csproj
+++ b/Source/Icebreaker/Icebreaker.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Helpers\AdaptiveCards\UnrecognizedInputAdaptiveCard.cs" />
     <Compile Include="Helpers\AdaptiveCards\WelcomeNewMemberAdaptiveCard.cs" />
     <Compile Include="Helpers\AdaptiveCards\WelcomeTeamAdaptiveCard.cs" />
+    <Compile Include="Helpers\Extensions.cs" />
     <Compile Include="Helpers\IcebreakerBotDataProvider.cs" />
     <Compile Include="Helpers\TeamInstallInfo.cs" />
     <Compile Include="Helpers\UserInfo.cs" />

--- a/Source/Icebreaker/IcebreakerBot.cs
+++ b/Source/Icebreaker/IcebreakerBot.cs
@@ -289,11 +289,14 @@ namespace Icebreaker
             var teamsPerson1 = pair.Item1.AsTeamsChannelAccount();
             var teamsPerson2 = pair.Item2.AsTeamsChannelAccount();
 
+            var emailOfPerson2 = teamsPerson2.UserPrincipalName.CaseInsensitiveContains("#ext#") ? teamsPerson2.Email : teamsPerson2.UserPrincipalName;
+            var emailOfPerson1 = teamsPerson1.UserPrincipalName.CaseInsensitiveContains("#ext#") ? teamsPerson1.Email : teamsPerson1.UserPrincipalName;
+
             // Fill in person2's info in the card for person1
-            var cardForPerson1 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson2.Name, teamsPerson1.Name, teamsPerson2.GivenName, teamsPerson1.GivenName, teamsPerson1.GivenName, teamsPerson2.UserPrincipalName, this.botDisplayName);
+            var cardForPerson1 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson2.Name, teamsPerson1.Name, teamsPerson2.GivenName, teamsPerson1.GivenName, teamsPerson1.GivenName, emailOfPerson2, this.botDisplayName);
 
             // Fill in person1's info in the card for person2
-            var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson1.Name, teamsPerson2.Name, teamsPerson1.GivenName, teamsPerson2.GivenName, teamsPerson2.GivenName, teamsPerson1.UserPrincipalName, this.botDisplayName);
+            var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson1.Name, teamsPerson2.Name, teamsPerson1.GivenName, teamsPerson2.GivenName, teamsPerson2.GivenName, emailOfPerson1, this.botDisplayName);
 
             // Send notifications and return the number that was successful
             var notifyResults = await Task.WhenAll(


### PR DESCRIPTION
Issue: Icebreaker Chat with user doesn't work for guest users

Fix: To be able to resolve this issue, I have created an extension method called CaseInsensitiveContains which takes the parameter of the extension `#ext#` and check it against the UserPrincipalName. If the extension exists - we will use the EmailAddress, otherwise we will default to using the UserPrincipalName.