### PR TITLE
Guest User Information Management

### DIFF
--- a/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
+++ b/Source/Icebreaker/Helpers/AdaptiveCards/PairUpNotificationAdaptiveCard.cs
@@ -11,6 +11,7 @@ namespace Icebreaker.Helpers.AdaptiveCards
     using System.IO;
     using System.Web.Hosting;
     using Icebreaker.Properties;
+    using Microsoft.Bot.Connector.Teams.Models;
 
     /// <summary>
     /// Builder class for the pairup notification card
@@ -28,30 +29,30 @@ namespace Icebreaker.Helpers.AdaptiveCards
         /// <summary>
         /// Creates the pairup notification card.
         /// </summary>
-        /// <param name="teamName">Name of the team</param>
-        /// <param name="firstPersonName">Name of the matched person</param>
-        /// <param name="secondPersonName">First name of the matched person</param>
-        /// <param name="firstPersonFirstName">First name of the first person</param>
-        /// <param name="secondPersonFirstName">First name of the second person</param>
-        /// <param name="receiverName">Name of the receiver</param>
-        /// <param name="personUpn">UPN of the person</param>
-        /// <param name="botDisplayName">This is the display name of the bot that is set from the deployment</param>
+        /// <param name="teamName">The team name.</param>
+        /// <param name="firstPerson">The first <see cref="TeamsChannelAccount"/> of the matched pair.</param>
+        /// <param name="secondPerson">The second <see cref="TeamsChannelAccount"/> of the matched pair.</param>
+        /// <param name="botDisplayName">The bot display name.</param>
         /// <returns>Pairup notification card</returns>
-        public static string GetCard(string teamName, string firstPersonName, string secondPersonName, string firstPersonFirstName, string secondPersonFirstName, string receiverName, string personUpn, string botDisplayName)
+        public static string GetCard(string teamName, TeamsChannelAccount firstPerson, TeamsChannelAccount secondPerson, string botDisplayName)
         {
+            var firstPersonFirstName = string.IsNullOrEmpty(firstPerson.GivenName) ? firstPerson.Name : firstPerson.GivenName;
+            var secondPersonFirstName = string.IsNullOrEmpty(secondPerson.GivenName) ? secondPerson.Name : secondPerson.GivenName;
+
             var title = string.Format(Resources.MeetupTitle, firstPersonFirstName, secondPersonFirstName);
             var escapedTitle = Uri.EscapeDataString(title);
 
             var content = string.Format(Resources.MeetupContent, botDisplayName);
             var escapedContent = Uri.EscapeDataString(content);
 
+            var personUpn = IsGuestUser(secondPerson) ? secondPerson.Email : secondPerson.UserPrincipalName;
             var meetingLink = "https://teams.microsoft.com/l/meeting/new?subject=" + escapedTitle + "&attendees=" + personUpn + "&content=" + escapedContent;
 
             var matchUpCardTitleContent = Resources.MatchUpCardTitleContent;
-            var matchUpCardMatchedText = string.Format(Resources.MatchUpCardMatchedText, firstPersonName);
-            var matchUpCardContentPart1 = string.Format(Resources.MatchUpCardContentPart1, botDisplayName, teamName, firstPersonName);
+            var matchUpCardMatchedText = string.Format(Resources.MatchUpCardMatchedText, secondPerson.Name);
+            var matchUpCardContentPart1 = string.Format(Resources.MatchUpCardContentPart1, botDisplayName, teamName, secondPerson.Name);
             var matchUpCardContentPart2 = Resources.MatchUpCardContentPart2;
-            var chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, firstPersonFirstName);
+            var chatWithMatchButtonText = string.Format(Resources.ChatWithMatchButtonText, secondPersonFirstName);
             var pauseMatchesButtonText = Resources.PausePairingsButtonText;
             var proposeMeetupButtonText = Resources.ProposeMeetupButtonText;
 
@@ -75,6 +76,16 @@ namespace Icebreaker.Helpers.AdaptiveCards
             }
 
             return cardBody;
+        }
+
+        /// <summary>
+        /// Checks whether or not the account is a guest user.
+        /// </summary>
+        /// <param name="account">The <see cref="TeamsChannelAccount"/> user to check.</param>
+        /// <returns>A value to indicate if the account is a user.</returns>
+        private static bool IsGuestUser(TeamsChannelAccount account)
+        {
+            return account.UserPrincipalName.IndexOf("#ext#", StringComparison.InvariantCultureIgnoreCase) >= 0;
         }
     }
 }

--- a/Source/Icebreaker/IcebreakerBot.cs
+++ b/Source/Icebreaker/IcebreakerBot.cs
@@ -289,14 +289,11 @@ namespace Icebreaker
             var teamsPerson1 = pair.Item1.AsTeamsChannelAccount();
             var teamsPerson2 = pair.Item2.AsTeamsChannelAccount();
 
-            var nameOfPerson2 = teamsPerson2.Name != null ? teamsPerson2.Name : teamsPerson2.GivenName;
-            var nameOfPerson1 = teamsPerson1.Name != null ? teamsPerson1.Name : teamsPerson1.GivenName;
-
             // Fill in person2's info in the card for person1
-            var cardForPerson1 = PairUpNotificationAdaptiveCard.GetCard(teamName, nameOfPerson2, nameOfPerson1, teamsPerson2.GivenName, teamsPerson1.GivenName, teamsPerson1.GivenName, teamsPerson2.UserPrincipalName, this.botDisplayName);
+            var cardForPerson1 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson1, teamsPerson2, this.botDisplayName);
 
             // Fill in person1's info in the card for person2
-            var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, nameOfPerson1, nameOfPerson2, teamsPerson1.GivenName, teamsPerson2.GivenName, teamsPerson2.GivenName, teamsPerson1.UserPrincipalName, this.botDisplayName);
+            var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson2, teamsPerson1, this.botDisplayName);
 
             // Send notifications and return the number that was successful
             var notifyResults = await Task.WhenAll(

--- a/Source/Icebreaker/IcebreakerBot.cs
+++ b/Source/Icebreaker/IcebreakerBot.cs
@@ -289,11 +289,14 @@ namespace Icebreaker
             var teamsPerson1 = pair.Item1.AsTeamsChannelAccount();
             var teamsPerson2 = pair.Item2.AsTeamsChannelAccount();
 
+            var nameOfPerson2 = teamsPerson2.Name != null ? teamsPerson2.Name : teamsPerson2.GivenName;
+            var nameOfPerson1 = teamsPerson1.Name != null ? teamsPerson1.Name : teamsPerson1.GivenName;
+
             // Fill in person2's info in the card for person1
-            var cardForPerson1 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson2.Name, teamsPerson1.Name, teamsPerson2.GivenName, teamsPerson1.GivenName, teamsPerson1.GivenName, teamsPerson2.UserPrincipalName, this.botDisplayName);
+            var cardForPerson1 = PairUpNotificationAdaptiveCard.GetCard(teamName, nameOfPerson2, nameOfPerson1, teamsPerson2.GivenName, teamsPerson1.GivenName, teamsPerson1.GivenName, teamsPerson2.UserPrincipalName, this.botDisplayName);
 
             // Fill in person1's info in the card for person2
-            var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, teamsPerson1.Name, teamsPerson2.Name, teamsPerson1.GivenName, teamsPerson2.GivenName, teamsPerson2.GivenName, teamsPerson1.UserPrincipalName, this.botDisplayName);
+            var cardForPerson2 = PairUpNotificationAdaptiveCard.GetCard(teamName, nameOfPerson1, nameOfPerson2, teamsPerson1.GivenName, teamsPerson2.GivenName, teamsPerson2.GivenName, teamsPerson1.UserPrincipalName, this.botDisplayName);
 
             // Send notifications and return the number that was successful
             var notifyResults = await Task.WhenAll(


### PR DESCRIPTION
This PR resolves the following two issues: 
Issue #45 and Issue #46 

Fixes:
For Issue #45 - Making sure to extract the email from the upn which has the string "#ext#" contained in the UPN - created a helper method called IsGuestUser.
For Issue #46 - If the given name is null or empty, then we default to the display name of the guest users.