### PR TITLE
Trigger a refresh of the bot token up front before matching users

### DIFF
--- a/Source/Icebreaker/Controllers/ProcessNowController.cs
+++ b/Source/Icebreaker/Controllers/ProcessNowController.cs
@@ -9,7 +9,6 @@ namespace Icebreaker.Controllers
     using System.Threading.Tasks;
     using System.Web.Hosting;
     using System.Web.Http;
-    using Microsoft.ApplicationInsights;
     using Microsoft.Azure;
     using Microsoft.Bot.Connector;
 

--- a/Source/Icebreaker/Controllers/ProcessNowController.cs
+++ b/Source/Icebreaker/Controllers/ProcessNowController.cs
@@ -19,19 +19,16 @@ namespace Icebreaker.Controllers
     public class ProcessNowController : ApiController
     {
         private readonly IcebreakerBot bot;
-        private readonly TelemetryClient telemetryClient;
         private readonly MicrosoftAppCredentials botCredentials;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProcessNowController"/> class.
         /// </summary>
         /// <param name="bot">The Icebreaker bot instance</param>
-        /// <param name="telemetryClient">The telemetry client to use</param>
         /// <param name="botCredentials">The bot AAD credentials</param>
-        public ProcessNowController(IcebreakerBot bot, TelemetryClient telemetryClient, MicrosoftAppCredentials botCredentials)
+        public ProcessNowController(IcebreakerBot bot, MicrosoftAppCredentials botCredentials)
         {
             this.bot = bot;
-            this.telemetryClient = telemetryClient;
             this.botCredentials = botCredentials;
         }
 


### PR DESCRIPTION
BF v3 MicrosoftAppCredentials.GetTokenAsync() can sometimes return an expired token because of a race condition. Added a call to GetTokenAsync() to ensure that we either have a valid token, or a token refresh will be in progress when we do the pairups.

(This fixes issue #53)