### PR TITLE
Consider previous matches in matching process to reduce duplicate pairs

### DIFF
--- a/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
+++ b/Source/Icebreaker/Helpers/IcebreakerBotDataProvider.cs
@@ -159,6 +159,30 @@ namespace Icebreaker.Helpers
         }
 
         /// <summary>
+        /// Set the user info for the given user
+        /// </summary>
+        /// <param name="tenantId">Tenant id</param>
+        /// <param name="userId">User id</param>
+        /// <param name="optedIn">User opt-in status</param>
+        /// <param name="serviceUrl">User service URL</param>
+        /// <param name="recentPairUps">User recent pairs</param>
+        /// <returns>Tracking task</returns>
+        public async Task SetUserInfoAsync(string tenantId, string userId, bool optedIn, string serviceUrl, List<UserInfo> recentPairUps)
+        {
+            await this.EnsureInitializedAsync();
+
+            var userInfo = new UserInfo
+            {
+                TenantId = tenantId,
+                UserId = userId,
+                OptedIn = optedIn,
+                ServiceUrl = serviceUrl,
+                RecentPairUps = recentPairUps
+            };
+            await this.documentClient.UpsertDocumentAsync(this.usersCollection.SelfLink, userInfo);
+        }
+
+        /// <summary>
         /// Initializes the database connection.
         /// </summary>
         /// <returns>Tracking task</returns>

--- a/Source/Icebreaker/IcebreakerBot.cs
+++ b/Source/Icebreaker/IcebreakerBot.cs
@@ -418,6 +418,12 @@ namespace Icebreaker
             LinkedList<ChannelAccount> queue = new LinkedList<ChannelAccount>(users);
             var pairs = new List<Tuple<ChannelAccount, ChannelAccount>>();
 
+            /*
+             * The idea of the following matching algorithm is as follows:
+             * Pick first user X from queue.
+             * Find in FIFO manner from the rest of the queue the first user Y such that X and Y have not been "recently paired".
+             * If no such perfect pairing is possible, match with next user in queue.
+             */
             while (queue.Count > 0)
             {
                 ChannelAccount pairUserOne = queue.First.Value;
@@ -456,6 +462,11 @@ namespace Icebreaker
             return pairs;
         }
 
+        /// <summary>
+        /// This method serves to update the pair's respective "RecentlyPaired" fields with each other.
+        /// </summary>
+        /// <param name="userOneInfo">UserInfo of the first user in pair</param>
+        /// <param name="userTwoInfo">UserInfo of the second user in pair</param>
         private async void UpdateUserRecentlyPairedAsync(UserInfo userOneInfo, UserInfo userTwoInfo)
         {
             int maxRecentPairsToSave = 3;
@@ -477,6 +488,12 @@ namespace Icebreaker
             await this.dataProvider.SetUserInfoAsync(userTwoInfo.TenantId, userTwoInfo.UserId, userTwoInfo.OptedIn, userTwoInfo.ServiceUrl, userTwoInfo.RecentPairUps);
         }
 
+        /// <summary>
+        /// This method returns True if UserOne in pair was not 'recently matched' with UserTwo
+        /// </summary>
+        /// <param name="userOneInfo">UserInfo of the first user in pair</param>
+        /// <param name="userTwoInfo">UserInfo of the second user in pair</param>
+        /// <returns>True if users were NOT paired recently</returns>
         private bool SamePairNotCreatedRecently(UserInfo userOneInfo, UserInfo userTwoInfo)
         {
             foreach (UserInfo userTwoRecentPair in userTwoInfo.RecentPairUps)


### PR DESCRIPTION
This PR seeks to target the ongoing issue of #56.

During the matching process, sometimes users get paired with the same user that they have been matched with "recently". This PR seeks to optimize the current matching algorithm to minimize the occurrence of this experience. 

Basic Idea: 
- Leverage the already existing attribute "RecentPairUps" in UserInfo to store a record of the last 3 users that the user has been paired with. 
- In process of matching users, pick a user X. Then find a user Y in the rest of this list (queue) such that X has not been matched with Y recently.
- Update this attribute "RecentPairUps" everytime a new pair is made. We will only store up to the most recent 3 users that the user has been matched with.