### PR TITLE
Fix deployment issue when Az CLI output is not set to JSON format

### DIFF
--- a/Deployment/deploy.ps1
+++ b/Deployment/deploy.ps1
@@ -555,7 +555,13 @@ function InstallDependencies {
     # Initialize connections - Azure Az/CLI/Azure AD
     WriteInfo "Login with with your Azure subscription account. Launching Azure sign-in window..."
     Connect-AzAccount -Subscription $parameters.subscriptionId.Value -ErrorAction Stop
-    $user = az login --tenant $parameters.subscriptionTenantId.value
+    $user = az login --tenant $parameters.subscriptionTenantId.value -o json
+    
+    # Save user Az CLI output format config (default json) and change it to JSON
+    $outputUserConfig = az config get core.output -o json
+    $savedOutputConfig = ($outputUserConfig | convertfrom-json).value
+    az config set core.output=json
+
     if ($LASTEXITCODE -ne 0) {
         WriteError "Login failed for user..."
         EXIT
@@ -581,6 +587,9 @@ function InstallDependencies {
 
     # Assigning return values to variable. 
     $appdomainName = $deploymentOutput.properties.Outputs.appDomain.Value
+
+    # Restore user Az CLI output settings
+    az config set core.output=$savedOutputConfig
 
     # Log out to avoid tokens caching
     logout


### PR DESCRIPTION
The deploy.ps1 script fails with error message "Error message: Conversion from JSON failed with error: Error parsing NaN value" if the default output format of Az CLI is not JSON (e.g. if set to TSV or any other available format - https://docs.microsoft.com/en-us/cli/azure/format-output-azure-cli)
I suggest this fix to save the user environment settings, change them to json and then restore the setting to the original value.
Alternative approach : check output settings and display a warning message if not set to default JSON format