### PR TITLE
Change App Registration name to be AppDisplayName

### DIFF
--- a/Deployment/deploy.ps1
+++ b/Deployment/deploy.ps1
@@ -564,7 +564,7 @@ function InstallDependencies {
     $userAlias = (($user | ConvertFrom-Json) | where {$_.id -eq $parameters.subscriptionId.Value}).user.name
 
     # Create User App
-    $userAppCred = CreateAzureADApp $parameters.baseResourceName.Value
+    $userAppCred = CreateAzureADApp $parameters.appDisplayName.Value
     if ($null -eq $userAppCred) {
         WriteError "Failed to create or update the app in Azure Active Directory. Exiting..."
         logout


### PR DESCRIPTION
It makes more sense to use the parameter "App Display Name" for the app registration in Azure AD
The baseResourceName is a technical data, appended with random string
A user facing / friendly name in AzureAD (taht represents the app) should be the App Display Name instead